### PR TITLE
Add `CompositeOperation` type for specifying Porter Duff operators

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
     - windows
 julia:
     - 1.0
-    - 1
+    - 1.4 # explicitly specify 1.4 instead of 1 as a workaround
     - nightly
 notifications:
     email: false

--- a/src/ColorBlendModes.jl
+++ b/src/ColorBlendModes.jl
@@ -22,6 +22,9 @@ export BlendMode,
        BlendSaturation,
        BlendColor,
        BlendLuminosity
+export CompositeOperation,
+       CompositeSourceOver,
+       CompositeSourceAtop
 export blend, keyword
 
 include("types.jl")

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -5,20 +5,23 @@ _n(v::T) where T = oneunit(T) - v
 # linear interpolation
 _w(v1::T, v2::T, w) where T = convert(T, muladd(_n(w), v1, w * v2))
 
-@inline (mode::BlendMode)(c1, c2; opacity=nothing, clipping=false) =
-    _blend(mode, c1, c2, opacity, Val{clipping})
+@inline (mode::BlendMode)(c1, c2; opacity=nothing, op=CompositeSourceOver) =
+    _blend(mode, c1, c2, opacity, op)
+
+@inline (op::CompositeOperation)(c1, c2; opacity=nothing, mode=BlendNormal) =
+    _blend(mode, c1, c2, opacity, op)
 
 """
-    blend(c1, c2; mode=BlendNormal, opacity=1)
+    blend(c1, c2; mode=BlendNormal, opacity=nothing, op=CompositeSourceOver)
 """
-@inline blend(c1, c2; mode::BlendMode=BlendNormal, opacity=nothing, clipping=false) =
-    _blend(mode, c1, c2, opacity, Val{clipping})
+@inline blend(c1, c2; mode::BlendMode=BlendNormal, opacity=nothing, op=CompositeSourceOver) =
+    _blend(mode, c1, c2, opacity, op)
 
-# drop clipping kwarg
-@inline _blend(mode::BlendMode, c1, c2, opacity, ::Type{Val{false}}) =
+# drop op kwarg
+@inline _blend(mode::BlendMode, c1::TransparentColor, c2, opacity, ::CompositeOperation{Symbol("source-over")}) =
     _blend(mode, c1, c2, opacity)
 
-@inline _blend(mode::BlendMode, c1::Color, c2, opacity, ::Type{Val{true}}) =
+@inline _blend(mode::BlendMode, c1::Color, c2, opacity, ::DestAlphaFreeOperaions) =
     _blend(mode, c1, c2, opacity)
 
 # without opacity

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -24,3 +24,15 @@ function Base.parse(::Type{<:BlendMode}, keyword::AbstractString)
     kl in mode_keywords && return BlendMode{Symbol(kl)}()
     throw(ArgumentError("invalid keyword: $keyword"))
 end
+
+const op_keywords = [
+    "source-over",
+    "source-atop",
+]
+
+function Base.parse(::Type{<:CompositeOperation}, keyword::AbstractString)
+    keyword in op_keywords && return CompositeOperation{Symbol(keyword)}()
+    kl = lowercase(strip(keyword))
+    kl in op_keywords && return CompositeOperation{Symbol(kl)}()
+    throw(ArgumentError("invalid keyword: $keyword"))
+end

--- a/src/traits.jl
+++ b/src/traits.jl
@@ -1,2 +1,3 @@
 
 keyword(::BlendMode{sym}) where sym = string(sym)
+keyword(::CompositeOperation{sym}) where sym = string(sym)

--- a/src/types.jl
+++ b/src/types.jl
@@ -120,3 +120,24 @@ const NonSeparableBlendMode = Union{
     BlendMode{:color},
     BlendMode{:luminosity},
 }
+
+"""
+    CompositeOperation{op}
+"""
+struct CompositeOperation{op} end
+
+"""
+    CompositeSourceOver
+"""
+const CompositeSourceOver = CompositeOperation{Symbol("source-over")}()
+
+
+"""
+    CompositeSourceAtop
+"""
+const CompositeSourceAtop = CompositeOperation{Symbol("source-atop")}()
+
+const DestAlphaFreeOperaions = Union{
+    CompositeOperation{Symbol("source-over")},
+    CompositeOperation{Symbol("source-atop")},
+}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -253,10 +253,14 @@ end
 @testset "keyword" begin
     @test keyword(BlendNormal) == "normal"
     @test keyword(BlendColorDodge) == "color-dodge"
+
+    @test keyword(CompositeSourceOver) == "source-over"
 end
 
 @testset "parse" begin
     @test parse(BlendMode, "color-burn") === BlendColorBurn
     @test parse(BlendMode, "Hard-Light") === BlendHardLight
     @test_throws ArgumentError parse(BlendMode, "SoftLight")
+
+    @test parse(CompositeOperation, "source-over") === CompositeSourceOver
 end


### PR DESCRIPTION
Currently only "source-over" works.