### PR TITLE
Fix hue blending between a gray and a non-gray

### DIFF
--- a/docs/src/color-space-dependence.md
+++ b/docs/src/color-space-dependence.md
@@ -64,6 +64,21 @@ julia> blend(c1, blend(c2, c3))
 HSL{Float64}(240.0,1.0,0.8)
 ```
 
+In addition, in the case of blending a gray, i.e., a color with zero saturation,
+and a non-gray, the hue of the non-gray color is used.
+
+```jldoctest; setup=(using ColorTypes, ColorBlendModes;)
+julia> for w in 0.0:0.2:1.0 # gray to yellow green, not via brown
+           println(blend(HSI(12.3, 0.0, 0.5), HSI(78.9, 1.0, 0.5), opacity=w))
+       end
+HSI{Float64}(78.9,0.0,0.5)
+HSI{Float64}(78.9,0.2,0.5)
+HSI{Float64}(78.9,0.4,0.5)
+HSI{Float64}(78.9,0.6,0.5)
+HSI{Float64}(78.9,0.8,0.5)
+HSI{Float64}(78.9,1.0,0.5)
+```
+
 ## Gamma correction
 
 The [`blend`](@ref) function blends colors in a "uniform" space. Note that this

--- a/src/types.jl
+++ b/src/types.jl
@@ -3,6 +3,14 @@ const TransparentColorN{N,C<:Color,T} = TransparentColor{C,T,N}
 
 struct Hue{T<:Real}
     angle::T
+    isgray::Bool
+    Hue(angle::T, isgray::Bool=false) where {T <: Real} = new{T}(angle, isgray)
+    Hue(c::C) where {T, C<:Union{HSV{T}, HSL{T}, HSI{T},
+                                 AHSV{T}, AHSL{T}, AHSI{T}, HSVA{T}, HSLA{T}, HSIA{T}}} =
+        new{T}(c.h, c.s == zero(T))
+    Hue(c::C) where {T, C<:Union{LCHab{T}, LCHuv{T},
+                                 ALCHab{T}, ALCHuv{T}, LCHabA{T}, LCHuvA{T}}} =
+        new{T}(c.h, c.c == zero(T))
 end
 
 const SeparableBlendMode = Union{

--- a/test/blend_hsx.jl
+++ b/test/blend_hsx.jl
@@ -20,4 +20,8 @@
     @testset "$A over $A: $T" for T in (Float64, Float32)
         @test BlendNormal(A{T}(100,  0.75, 0, 0.6), A{T}(0, 0.5, 1, 0.6)) ≈ A{T}(200/7, 4/7, 5/7, 0.84)
     end
+
+    @testset "$C over gray $C: $T" for T in (Float64, Float32)
+        @test blend(C{T}(100, 0, 1), C{T}(200, 1, 0.5), opacity=0.5) ≈ C{T}(200, 0.5, 0.75)
+    end
 end

--- a/test/blend_lab.jl
+++ b/test/blend_lab.jl
@@ -36,3 +36,9 @@
         @test BlendNormal(A{T}(90, 80, 70, 0.6), A{T}(60, 50, -40, 0.6)) ≈ A{T}(68.57142857142857, 58.57142857142857, -8.57142857142857, 0.84)
     end
 end
+
+@testset "$C" for C in (LCHab, LCHuv)
+    @testset "$C over gray $C: $T" for T in (Float64, Float32)
+        @test blend(C{T}(40, 0, 100), C{T}(60, 100, 200), opacity=0.5) ≈ C{T}(50, 50, 200)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -95,6 +95,13 @@ end
     @test ColorBlendModes._w(Hue(175.0), 0.4, Hue(185.0), 0.6) ≈ 181.0
     @test ColorBlendModes._w(Hue(230.0), 0.4, Hue(30.0), 0.6) ≈ 326.0
     @test ColorBlendModes._w(Hue(5.0), 0.4, Hue(355.0), 0.6) ≈ 359.0
+
+    @test ColorBlendModes._w(Hue(30.0, true), Hue(130.0), 0.0) ≈ 130.0
+    @test ColorBlendModes._w(Hue(30.0, true), Hue(130.0), 0.6) ≈ 130.0
+    @test ColorBlendModes._w(Hue(30.0, true), Hue(130.0), 1.0) ≈ 130.0
+    @test ColorBlendModes._w(Hue(30.0), Hue(130.0, true), 0.0) ≈ 30.0
+    @test ColorBlendModes._w(Hue(30.0), Hue(130.0, true), 0.6) ≈ 30.0
+    @test ColorBlendModes._w(Hue(30.0), Hue(130.0, true), 1.0) ≈ 30.0
 end
 
 @testset "blend: RGB" begin


### PR DESCRIPTION
Fixes #28

This is not a matter of which is right and which is wrong, but ColorBlendModes is more concerned with visual properties than with algebraic properties. 

![hue](https://user-images.githubusercontent.com/12679384/92324778-aea84e80-f07f-11ea-9672-de99b348fc75.png)
