### PR TITLE
Version 0.2.3

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,5 +1,6 @@
 ---
 kind: pipeline
+type: docker
 name: linux - arm - Julia 1.0
 
 platform:
@@ -14,6 +15,7 @@ steps:
 
 ---
 kind: pipeline
+type: docker
 name: linux - arm64 - Julia 1.0
 
 platform:
@@ -32,6 +34,26 @@ steps:
 
 ---
 kind: pipeline
+type: docker
+name: linux - arm - Julia 1
+
+platform:
+  os: linux
+  arch: arm
+
+steps:
+- name: build
+  image: julia:1
+  environment:
+    CODECOV_TOKEN:
+      from_secret: CODECOV_TOKEN
+  commands:
+  - julia --project=. --check-bounds=yes --color=yes -e 'using InteractiveUtils; versioninfo(); using Pkg; Pkg.build(); Pkg.test(coverage=true)'
+  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit_local(process_folder())'
+
+---
+kind: pipeline
+type: docker
 name: linux - arm64 - Julia 1
 
 platform:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ jobs:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         version:
           - '1.0'

--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,13 @@
 name = "ColorBlendModes"
 uuid = "60508b50-96e1-4007-9d6c-f475c410f16b"
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 
 [compat]
-ColorTypes = "0.8, 0.9, 0.10"
+ColorTypes = "0.8, 0.9, 0.10, 0.11"
 FixedPointNumbers = "0.6, 0.7, 0.8"
 julia = "1"
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,5 +5,4 @@ FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 PNGFiles = "f57f5aa1-a3ce-4bc8-8ab9-96f992907883"
 
 [compat]
-Documenter = "0.25"
 julia = "1"

--- a/docs/src/blending-and-compositing.md
+++ b/docs/src/blending-and-compositing.md
@@ -32,17 +32,17 @@ The [`blend`](@ref) function is compatible with the broadcasting. Therefore,
 you can blend two images with the same size.
 ```jldoctest ex; setup = :(using ColorBlendModes, ColorTypes, FixedPointNumbers;)
 julia> image1 = [RGB(r, 1, b) for r=0:1, b=0:1]
-2×2 Array{RGB{N0f8},2} with eltype RGB{Normed{UInt8,8}}:
+2×2 Array{RGB{N0f8},2} with eltype RGB{N0f8}:
  RGB{N0f8}(0.0,1.0,0.0)  RGB{N0f8}(0.0,1.0,1.0)
  RGB{N0f8}(1.0,1.0,0.0)  RGB{N0f8}(1.0,1.0,1.0)
 
 julia> image2 = [RGB(r, g, 0) for g=0:1, r=0:1]
-2×2 Array{RGB{N0f8},2} with eltype RGB{Normed{UInt8,8}}:
+2×2 Array{RGB{N0f8},2} with eltype RGB{N0f8}:
  RGB{N0f8}(0.0,0.0,0.0)  RGB{N0f8}(1.0,0.0,0.0)
  RGB{N0f8}(0.0,1.0,0.0)  RGB{N0f8}(1.0,1.0,0.0)
 
 julia> blend.(image1, image2, mode=BlendMultiply)
-2×2 Array{RGB{N0f8},2} with eltype RGB{Normed{UInt8,8}}:
+2×2 Array{RGB{N0f8},2} with eltype RGB{N0f8}:
  RGB{N0f8}(0.0,0.0,0.0)  RGB{N0f8}(0.0,0.0,0.0)
  RGB{N0f8}(0.0,1.0,0.0)  RGB{N0f8}(1.0,1.0,0.0)
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -19,17 +19,17 @@ julia> blend(RGB(1, 1, 0), RGB(0, 1, 1), mode=BlendDarken)
 RGB{N0f8}(0.0,1.0,0.0)
 
 julia> image1 = [RGB(r, 1, b) for r=0:1, b=0:1]
-2×2 Array{RGB{N0f8},2} with eltype RGB{Normed{UInt8,8}}:
+2×2 Array{RGB{N0f8},2} with eltype RGB{N0f8}:
  RGB{N0f8}(0.0,1.0,0.0)  RGB{N0f8}(0.0,1.0,1.0)
  RGB{N0f8}(1.0,1.0,0.0)  RGB{N0f8}(1.0,1.0,1.0)
 
 julia> image2 = [RGB(r, g, 0) for g=0:1, r=0:1]
-2×2 Array{RGB{N0f8},2} with eltype RGB{Normed{UInt8,8}}:
+2×2 Array{RGB{N0f8},2} with eltype RGB{N0f8}:
  RGB{N0f8}(0.0,0.0,0.0)  RGB{N0f8}(1.0,0.0,0.0)
  RGB{N0f8}(0.0,1.0,0.0)  RGB{N0f8}(1.0,1.0,0.0)
 
 julia> BlendDifference.(image1, image2)
-2×2 Array{RGB{N0f8},2} with eltype RGB{Normed{UInt8,8}}:
+2×2 Array{RGB{N0f8},2} with eltype RGB{N0f8}:
  RGB{N0f8}(0.0,1.0,0.0)  RGB{N0f8}(1.0,1.0,1.0)
  RGB{N0f8}(1.0,0.0,0.0)  RGB{N0f8}(0.0,0.0,1.0)
 ```


### PR DESCRIPTION
This adds support for ColorTypes v0.11.

The x86 (32-bit) test is failing, but I have not been able to identify the cause. My local WOW64 environment does not reproduce the problem. 32-bit ARM is also fine.

In any case, it is unrelated to ColorTypes v0.11, so I will release v0.2.3 first.